### PR TITLE
All output struct now derive Clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,7 +840,7 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "mexc-rs"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mexc-rs"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 license-file = "LICENSE"
 readme = "README.md"

--- a/src/spot/v3/account_information.rs
+++ b/src/spot/v3/account_information.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountInformationOutput {
     pub maker_commission: Option<Decimal>,
@@ -21,7 +21,7 @@ pub struct AccountInformationOutput {
     pub permissions: Vec<String>,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountBalance {
     pub asset: String,

--- a/src/spot/v3/avg_price.rs
+++ b/src/spot/v3/avg_price.rs
@@ -10,7 +10,7 @@ pub struct AvgParams<'a> {
     pub symbol: &'a str,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AvgOutput {
     pub mins: u64,

--- a/src/spot/v3/cancel_all_open_orders_on_a_symbol.rs
+++ b/src/spot/v3/cancel_all_open_orders_on_a_symbol.rs
@@ -31,12 +31,12 @@ impl<'a> From<CancelAllOpenOrdersOnASymbolParams<'a>> for CancelAllOpenOrdersOnA
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CancelAllOpenOrdersOnASymbolOutput {
     pub canceled_orders: Vec<CanceledOrder>,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CanceledOrder {
     pub symbol: String,

--- a/src/spot/v3/cancel_order.rs
+++ b/src/spot/v3/cancel_order.rs
@@ -41,7 +41,7 @@ impl<'a> From<CancelOrderParams<'a>> for CancelOrderQuery<'a> {
     }
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CancelOrderOutput {
     pub symbol: String,

--- a/src/spot/v3/create_user_data_stream.rs
+++ b/src/spot/v3/create_user_data_stream.rs
@@ -9,7 +9,7 @@ pub struct CreateUserDataStreamQuery {
     timestamp: DateTime<Utc>,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateUserDataStreamOutput {
     pub listen_key: String,

--- a/src/spot/v3/default_symbols.rs
+++ b/src/spot/v3/default_symbols.rs
@@ -4,7 +4,7 @@ use crate::spot::{
 };
 use async_trait::async_trait;
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DefaultsSymbolsOutput {
     pub code: i32,

--- a/src/spot/v3/depth.rs
+++ b/src/spot/v3/depth.rs
@@ -12,13 +12,13 @@ pub struct DepthParams<'a> {
     pub limit: Option<u32>,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 pub struct PriceAndQuantity {
     pub price: Decimal,
     pub quantity: Decimal,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DepthOutput {
     pub last_update_id: u64,

--- a/src/spot/v3/exchange_information.rs
+++ b/src/spot/v3/exchange_information.rs
@@ -12,7 +12,7 @@ pub enum ExchangeInformationParams<'a> {
     Symbols(&'a [&'a str]),
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ExchangeInformationSymbol {
     pub symbol: String,
@@ -37,7 +37,7 @@ pub struct ExchangeInformationSymbol {
     pub taker_commission: Decimal,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ExchangeInformationOutput {
     pub timezone: String,

--- a/src/spot/v3/get_open_orders.rs
+++ b/src/spot/v3/get_open_orders.rs
@@ -30,7 +30,7 @@ impl<'a> From<GetOpenOrdersParams<'a>> for GetOrderQuery<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GetOrderOutput {
     pub orders: Vec<Order>,
 }

--- a/src/spot/v3/keep_alive_user_data_stream.rs
+++ b/src/spot/v3/keep_alive_user_data_stream.rs
@@ -16,7 +16,7 @@ pub struct KeepAliveUserDataStreamQuery<'a> {
     listen_key: &'a str,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct KeepAliveUserDataStreamOutput {
     pub listen_key: String,

--- a/src/spot/v3/klines.rs
+++ b/src/spot/v3/klines.rs
@@ -22,13 +22,13 @@ pub struct KlinesParams<'a> {
     pub limit: Option<u32>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct KlinesOutput {
     pub klines: Vec<Kline>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Kline {
     #[serde(with = "chrono::serde::ts_seconds")]

--- a/src/spot/v3/models.rs
+++ b/src/spot/v3/models.rs
@@ -2,7 +2,7 @@ use crate::spot::v3::enums::{OrderSide, OrderStatus, OrderType};
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Order {
     pub symbol: String,

--- a/src/spot/v3/order.rs
+++ b/src/spot/v3/order.rs
@@ -54,7 +54,7 @@ impl<'a> From<OrderParams<'a>> for OrderQuery<'a> {
     }
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderOutput {
     pub symbol: String,

--- a/src/spot/v3/order.rs
+++ b/src/spot/v3/order.rs
@@ -74,6 +74,8 @@ pub trait OrderEndpoint {
     async fn order(&self, params: OrderParams<'_>) -> ApiResult<OrderOutput>;
 }
 
+// 04/05/2025 Note for anyone trying to implement /api/v3/order/test : it's useless, the api just check fied names
+
 #[async_trait]
 impl OrderEndpoint for MexcSpotApiClientWithAuthentication {
     async fn order(&self, params: OrderParams<'_>) -> ApiResult<OrderOutput> {

--- a/src/spot/v3/query_order.rs
+++ b/src/spot/v3/query_order.rs
@@ -38,7 +38,7 @@ impl<'a> From<QueryOrderParams<'a>> for QueryOrderQuery<'a> {
     }
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryOrderOutput {
     pub symbol: String,

--- a/src/spot/v3/time.rs
+++ b/src/spot/v3/time.rs
@@ -3,7 +3,7 @@ use crate::spot::MexcSpotApiTrait;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeOutput {
     #[serde(with = "chrono::serde::ts_seconds")]

--- a/src/spot/v3/trades.rs
+++ b/src/spot/v3/trades.rs
@@ -12,12 +12,12 @@ pub struct TradesParams<'a> {
     pub limit: Option<u32>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TradesOutput {
     pub trades: Vec<Trade>,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Trade {
     /// Currently always filled with null

--- a/src/spot/ws/subscribe.rs
+++ b/src/spot/ws/subscribe.rs
@@ -56,7 +56,7 @@ impl SubscribeParams {
     // }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SubscribeOutput {}
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
Simple PR to derive Clone for all return structures, making the user able to clone them.